### PR TITLE
Keep session alive using recovery code

### DIFF
--- a/src/wealthsimple/wealthsimple.py
+++ b/src/wealthsimple/wealthsimple.py
@@ -144,6 +144,32 @@ class WSTrade:
         else:
             raise Exception("Missing login credentials")
 
+    def get_recovery_code(self):
+        response = self.get_me()
+        user_id = response['external_hw_user_id']
+
+        data = {
+            "operationName": "createRecoveryCodesMutation",
+            "variables": """
+            {"user_id": "%s"}
+            """%user_id,
+            "query": """
+                mutation createRecoveryCodesMutation($user_id: String!) {
+                    createRecoveryCodes(user_id: $user_id) {
+                        recovery_code
+                        recovery_kit_url
+                        __typename
+                    }
+                }
+            """
+        }
+        
+        self.TradeAPI.APIMainURL = 'https://my.wealthsimple.com/'
+        response = self.TradeAPI.makeRequest('POST', 'graphql', data)
+        self.TradeAPI.APIMainURL = self.APIMAIN
+
+        return response.json()['data']['createRecoveryCodes']['recovery_code']
+
     def get_accounts(self) -> list:
         """Get Wealthsimple Trade accounts
 

--- a/src/wealthsimple/wealthsimple.py
+++ b/src/wealthsimple/wealthsimple.py
@@ -110,15 +110,14 @@ class WSTrade:
                 ("password", password),
             ]
 
+            if recovery_code:
+                data.append(("otp", recovery_code))
+
             response = self.TradeAPI.makeRequest("POST", "auth/login", data)
 
             # Check if account requires 2FA
-            if "x-wealthsimple-otp" in response.headers:
-                if recovery_code is not None:
-                    # Use the recovery code for login
-                    MFACode = recovery_code
-
-                elif two_factor_callback is not None:
+            if "x-wealthsimple-otp" in response.headers and not recovery_code:
+                if two_factor_callback is not None:
                     # Obtain 2FA code using callback function
                     MFACode = two_factor_callback()
 


### PR DESCRIPTION
This allows to specify a recovery code in the login method. If specified, it'll use it instead of asking for the 2FA.